### PR TITLE
Configuration possibilities for connection

### DIFF
--- a/src/main/java/net/iponweb/disthene/reader/config/ReaderConfiguration.java
+++ b/src/main/java/net/iponweb/disthene/reader/config/ReaderConfiguration.java
@@ -11,8 +11,35 @@ public class ReaderConfiguration {
     private int port;
     private int threads = 32;
     private int requestTimeout = 30;
+    private int maxInitialLineLength = 4096;
+    private int maxHeaderSize = 8192;
+    private int maxChunkSize = 8192;
     private int maxPoints = 60_000_000;
     private List<Rollup> rollups = new ArrayList<>();
+
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    public int getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    public int getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    public void setMaxInitialLineLength(int maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
+    }
+
+    public void setMaxHeaderSize(int maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
+    }
+
+    public void setMaxChunkSize(int maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
 
     public String getBind() {
         return bind;

--- a/src/main/java/net/iponweb/disthene/reader/server/ReaderServer.java
+++ b/src/main/java/net/iponweb/disthene/reader/server/ReaderServer.java
@@ -49,7 +49,11 @@ public class ReaderServer {
                     @Override
                     public void initChannel(SocketChannel ch) throws Exception {
                         ChannelPipeline p = ch.pipeline();
-                        p.addLast(new HttpRequestDecoder());
+                        p.addLast(new HttpRequestDecoder(
+		            configuration.getMaxInitialLineLength(),
+                            configuration.getMaxHeaderSize(),
+			    configuration.getMaxChunkSize()
+            		));
                         p.addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
                         p.addLast(new HttpResponseEncoder());
                         p.addLast(new HttpContentCompressor());


### PR DESCRIPTION
While testing the disthene-reader, we've ran into an issue where a multi-wildcard query would result in a large request being passed to disthene.

Due to default limits placed by the HttpRequestDecoder() constructor, this request would fail.

(Test was made with two wildcards resolving into a total of 999 metric query)
