### PR TITLE
Allow for empty tenant values and relative time periods

### DIFF
--- a/src/main/java/net/iponweb/disthene/reader/handler/MetricsHandler.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/MetricsHandler.java
@@ -77,7 +77,9 @@ public class MetricsHandler implements DistheneReaderHandler {
             MetricsParameters parameters =
                     new Gson().fromJson(((HttpContent) request).content().toString(Charset.defaultCharset()), MetricsParameters.class);
             if (parameters.getTenant() == null) {
-                throw new MissingParameterException("Tenant parameter is missing");
+                // assume tenant "NONE"
+                parameters.setTenant("NONE");
+                logger.debug("No tenant in request. Assuming value of NONE");
             }
             if (parameters.getPath().size() == 0) {
                 throw new MissingParameterException("Path parameter is missing");

--- a/src/main/java/net/iponweb/disthene/reader/handler/PathsHandler.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/PathsHandler.java
@@ -52,7 +52,8 @@ public class PathsHandler implements DistheneReaderHandler {
             if (queryStringDecoder.parameters().get("tenant") != null) {
                 parameters.setTenant(queryStringDecoder.parameters().get("tenant").get(0));
             } else {
-                throw new MissingParameterException("Tenant parameter is missing");
+                //throw new MissingParameterException("Tenant parameter is missing");
+                parameters.setTenant("NONE")
             }
             if (queryStringDecoder.parameters().get("query") != null) {
                 parameters.setQuery(queryStringDecoder.parameters().get("query").get(0));
@@ -65,7 +66,8 @@ public class PathsHandler implements DistheneReaderHandler {
             ((HttpContent) request).content().resetReaderIndex();
             PathsParameters parameters = new Gson().fromJson(((HttpContent) request).content().toString(Charset.defaultCharset()), PathsParameters.class);
             if (parameters.getTenant() == null) {
-                throw new MissingParameterException("Tenant parameter is missing");
+                //throw new MissingParameterException("Tenant parameter is missing");
+                parameters.setTenant("NONE")
             }
             if (parameters.getQuery() == null) {
                 throw new MissingParameterException("Query parameter is missing");

--- a/src/main/java/net/iponweb/disthene/reader/handler/PathsHandler.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/PathsHandler.java
@@ -52,8 +52,9 @@ public class PathsHandler implements DistheneReaderHandler {
             if (queryStringDecoder.parameters().get("tenant") != null) {
                 parameters.setTenant(queryStringDecoder.parameters().get("tenant").get(0));
             } else {
-                //throw new MissingParameterException("Tenant parameter is missing");
-                parameters.setTenant("NONE")
+                // assume tenant "NONE"
+                parameters.setTenant("NONE");
+                logger.debug("No tenant in request. Assuming value of NONE");
             }
             if (queryStringDecoder.parameters().get("query") != null) {
                 parameters.setQuery(queryStringDecoder.parameters().get("query").get(0));
@@ -66,8 +67,9 @@ public class PathsHandler implements DistheneReaderHandler {
             ((HttpContent) request).content().resetReaderIndex();
             PathsParameters parameters = new Gson().fromJson(((HttpContent) request).content().toString(Charset.defaultCharset()), PathsParameters.class);
             if (parameters.getTenant() == null) {
-                //throw new MissingParameterException("Tenant parameter is missing");
-                parameters.setTenant("NONE")
+                // assume tenant "NONE"
+                parameters.setTenant("NONE");
+                logger.debug("No tenant in request. Assuming value of NONE");
             }
             if (parameters.getQuery() == null) {
                 throw new MissingParameterException("Query parameter is missing");

--- a/src/main/java/net/iponweb/disthene/reader/handler/SearchHandler.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/SearchHandler.java
@@ -65,7 +65,9 @@ public class SearchHandler implements DistheneReaderHandler {
         if (queryStringDecoder.parameters().get("tenant") != null) {
             parameters.setTenant(queryStringDecoder.parameters().get("tenant").get(0));
         } else {
-            throw new MissingParameterException("Tenant parameter is missing");
+            // assume tenant "NONE"
+            parameters.setTenant("NONE");
+            logger.debug("No tenant in request. Assuming value of NONE");
         }
         if (queryStringDecoder.parameters().get("query") != null) {
             parameters.setQuery(Joiner.on("|").skipNulls().join(queryStringDecoder.parameters().get("query")));

--- a/src/main/java/net/iponweb/disthene/reader/handler/parameters/RenderParameters.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/parameters/RenderParameters.java
@@ -159,8 +159,6 @@ public class RenderParameters {
 
                 if (passedFromValue.matches("^.*[a-zA-Z]")) {
                     // a relative time character was found
-                    // split into number, unit
-
                     passedFromValue = passedFromValue.replace("-", ""); // remove signed value if present
 
                     String fromValue = "";

--- a/src/main/java/net/iponweb/disthene/reader/handler/parameters/RenderParameters.java
+++ b/src/main/java/net/iponweb/disthene/reader/handler/parameters/RenderParameters.java
@@ -15,6 +15,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.awt.*;
+import java.lang.String;
+import java.lang.Integer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -153,7 +155,52 @@ public class RenderParameters {
         // parse from defaulting to -1d
         if (queryStringDecoder.parameters().get("from") != null) {
             try {
-                parameters.setFrom(new DateTime(Long.valueOf(queryStringDecoder.parameters().get("from").get(0)) * 1000, parameters.getTz()).getMillis() / 1000L);
+                String passedFromValue = queryStringDecoder.parameters().get("from").get(0);
+
+                if (passedFromValue.matches("^.*[a-zA-Z]")) {
+                    // a relative time character was found
+                    // split into number, unit
+
+                    passedFromValue = passedFromValue.replace("-", ""); // remove signed value if present
+
+                    String fromValue = "";
+                    String fromUnit = "";
+                    String v = "";
+                    Long unitValue = 0L;
+
+                    for (int i = 0 ; i < passedFromValue.length() - 1 ; i++) {
+                        v = String.valueOf(passedFromValue.charAt(i));
+
+                        if (v.matches("[a-zA-Z]")) {
+                            fromUnit = fromUnit.concat(v);
+                        } else {
+                            fromValue = fromValue.concat(v);
+                        }
+                    }
+                    // calc unit value
+                    if (fromUnit.startsWith("s")) {
+                        unitValue = 1L;
+                    } else if (fromUnit.startsWith("min")) {
+                        unitValue = 60L;
+                    } else if (fromUnit.startsWith("h")) {
+                        unitValue = 3600L;
+                    } else if (fromUnit.startsWith("d")) {
+                        unitValue = 86400L;
+                    } else if (fromUnit.startsWith("w")) {
+                        unitValue = 604800L;
+                    } else if (fromUnit.startsWith("mon")) {
+                        unitValue = 18144000L;
+                    } else if (fromUnit.startsWith("y")) {
+                        unitValue = 31536000L;
+                    } else {
+                        unitValue = 60L;
+                    }
+                    // calc offset as (now) - (number * unit value)
+                    parameters.setFrom((System.currentTimeMillis() / 1000L) - (Long.valueOf(fromValue) * unitValue));
+                } else {
+                    // no only numeric time
+                    parameters.setFrom(new DateTime(Long.valueOf(queryStringDecoder.parameters().get("from").get(0)) * 1000, parameters.getTz()).getMillis() / 1000L);
+                }
             } catch (NumberFormatException e) {
                 throw new InvalidParameterValueException("DateTime format not recognized (from): " + queryStringDecoder.parameters().get("from").get(0));
             }
@@ -162,16 +209,63 @@ public class RenderParameters {
             parameters.setFrom((System.currentTimeMillis() / 1000L) - 86400);
         }
 
-        // parse until defaulting to -1d
+        // parse until
         if (queryStringDecoder.parameters().get("until") != null) {
             try {
-                parameters.setUntil(new DateTime(Long.valueOf(queryStringDecoder.parameters().get("until").get(0)) * 1000, parameters.getTz()).getMillis() / 1000L);
+               String passedUntilValue = queryStringDecoder.parameters().get("until").get(0);
+
+                if (passedUntilValue.matches("^.*[a-zA-Z]")) {
+                    // remove signed value if present
+                    passedUntilValue = passedUntilValue.replace("-", "");
+
+                    String untilValue = "";
+                    String untilUnit = "";
+                    String v = "";
+                    Long unitValue = 0L;
+
+                    for (int i = 0 ; i < passedUntilValue.length() - 1 ; i++) {
+                        v = String.valueOf(passedUntilValue.charAt(i));
+
+                        if (v.matches("[a-zA-Z]")) {
+                            untilUnit = untilUnit.concat(v);
+                        } else {
+                            untilValue = untilValue.concat(v);
+                        }
+                    }
+                    // calc unit value
+                    if (untilUnit.startsWith("s")) {
+                        unitValue = 1L;
+                    } else if (untilUnit.startsWith("min")) {
+                        unitValue = 60L;
+                    } else if (untilUnit.startsWith("h")) {
+                        unitValue = 3600L;
+                    } else if (untilUnit.startsWith("d")) {
+                        unitValue = 86400L;
+                    } else if (untilUnit.startsWith("w")) {
+                        unitValue = 604800L;
+                    } else if (untilUnit.startsWith("mon")) {
+                        unitValue = 18144000L;
+                    } else if (untilUnit.startsWith("y")) {
+                        unitValue = 31536000L;
+                    } else {
+                        unitValue = 60L;
+                    }
+                    // calc offset as (now) - (number * unit value)
+                    parameters.setUntil((System.currentTimeMillis() / 1000L) - (Long.valueOf(untilValue) * unitValue));
+                } else {
+                    parameters.setUntil(new DateTime(Long.valueOf(queryStringDecoder.parameters().get("until").get(0)) * 1000, parameters.getTz()).getMillis() / 1000L);
+                }
             } catch (NumberFormatException e) {
                 throw new InvalidParameterValueException("DateTime format not recognized (until): " + queryStringDecoder.parameters().get("until").get(0));
             }
         } else {
             // default to now
             parameters.setUntil(System.currentTimeMillis() / 1000L);
+        }
+
+        // Prohibiting "from greater than until"
+        if (parameters.getFrom() > parameters.getUntil()) {
+            parameters.setFrom(parameters.getUntil());
         }
 
         // Prohibiting "until in the future"


### PR DESCRIPTION
This allows for disthene-reader to gracefully fall back to a default tenant value of 'NONE' in the event that this isn't configured for a multi tenant environment. Additionally this also allow for the 'from' and 'until' render query values to be passed as relative time units similar to how traditional graphite would allow: eg `from=-3d&until=-48h`
