### PR TITLE
query ES only if there is wildcard path

### DIFF
--- a/src/main/java/net/iponweb/disthene/reader/utils/WildcardUtil.java
+++ b/src/main/java/net/iponweb/disthene/reader/utils/WildcardUtil.java
@@ -1,9 +1,16 @@
 package net.iponweb.disthene.reader.utils;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * @author Andrei Ivanov
  */
 public class WildcardUtil {
+
+    public static boolean isPlainPath(String path) {
+        char noPlainChars[] = {'*', '?', '{', '(', '['};
+        return !(StringUtils.containsAny(path, noPlainChars));
+    }
 
     public static String getPathsRegExFromWildcard(String wildcard) {
         return wildcard.replace(".", "\\.").replace("*", "[^\\.]*").replace("{", "(")


### PR DESCRIPTION
Paths without wildcards (/render) do not have to be queried against Elasticsearch.  It is common that paths are plain (without wildcards), moreover if there is graphite-web in front of disthene-reader all queries to `/render` are plain.
